### PR TITLE
Add better token checking & more information to the error

### DIFF
--- a/UII/README.md
+++ b/UII/README.md
@@ -5,7 +5,7 @@ Discord user information grabber via ID.
 ## Installation
 NPM Packages:
 
-    npm i axios
+    npm i
 
 ## Usage
 ```

--- a/UII/index.js
+++ b/UII/index.js
@@ -5,33 +5,33 @@ const Axios = require("axios")
 const Self_Args = process.argv.slice(2)
 
 //Main
-if(!Self_Args.length){
+if (!Self_Args.length) {
     console.log("node index.js <user_id> <discord_token>")
     process.exit()
 }
 
-if(isNaN(Self_Args[0])){
+if (isNaN(Self_Args[0])) {
     console.log("user_id is not a number.")
     process.exit()
 }
 
-if(!Self_Args[1]){
-    console.log("Invalid discord_token.")
-    process.exit()
+if (!/(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i.test(Self_Args[1])) {
+    console.error('you did not provide a valid token');
+    process.exit(1);
 }
 
-void async function Main(){
-    try{
-        var response = await Axios({
+void async function Main() {
+    try {
+        const response = await Axios({
             method: "GET",
-            url: `https://discord.com/api/v9/users/${Self_Args[0]}/profile?with_mutual_guilds=false`,
+            url: `https://discord.com/api/v9/users/${Self_Args[0]}/profile`,
             headers: {
-                authorization: Self_Args[1]
+                authorization: `${Self_Args[1]}`
             }
         })
 
-        user = response.data.user
-        ca = response.data.connected_accounts
+        const user = response.data.user
+        const ca = response.data.connected_accounts
 
         console.log(`
 Username: ${user.username}
@@ -41,14 +41,14 @@ Tag number: ${user.discriminator}
 BIO: ${user.bio}
 `)
 
-        for( i in ca ){
+        for (i in ca) {
             console.log(`Platform: ${ca[i].type}
 Name: ${ca[i].name}
 ID: ${ca[i].id}
 Verified: ${ca[i].verified}
 `)
         }
-    }catch{
-        console.log("Make sure user_id & discord_token is valid.")
+    } catch (e) {
+        console.log("Make sure user_id & discord_token is valid. If the provided information is valid, then that means that Discord is preventing you from viewing the profile of this user. This is most likely because you are trying to view the profile of a user that you haven't interacted with.\nError:", e.response.data)
     }
 }()

--- a/UII/package-lock.json
+++ b/UII/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "uii",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "uii",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.26.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "axios": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    }
+  }
+}

--- a/UII/package.json
+++ b/UII/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "uii",
+  "version": "1.0.0",
+  "description": "Grab a Discord user's information using just their ID",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/I2rys/ODiscord.git"
+  },
+  "author": "I2rys",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/I2rys/ODiscord/issues"
+  },
+  "homepage": "https://github.com/I2rys/ODiscord#readme",
+  "dependencies": {
+    "axios": "^0.26.0"
+  }
+}


### PR DESCRIPTION
If you are trying to view the profile of a user you haven't interacted with, then Discord will return a `403` status code. 
Your best bet is to use a bot token and make a request to `https://discord.com/api/v9/users/USERID`:
```javascript
fetch(`https://discord.com/api/v9/users/${user}`, {
        method: 'GET',
        headers: {
            'Authorization': `Bot BOT_TOKEN_HERE`
        }
    }).then(res => res.json()).then(json => {
        console.log(json);
    });